### PR TITLE
golf_score.rbのリファクタリング

### DIFF
--- a/ruby/golf_score.rb
+++ b/ruby/golf_score.rb
@@ -4,6 +4,7 @@ get_line = []
 par_scores = []
 player_scores = []
 judge_scores = []
+SCORE_MAPPING = { -3 => 'アルバトロス', -2 => 'イーグル', -1 => 'バーディ', 0 => 'パー', 1 => 'ボギー' }.freeze
 
 ARGF.each do |line|
   get_line << line
@@ -22,13 +23,7 @@ end
     par_scores[i] == 5 ? judge_scores << 'コンドル' : judge_scores << 'ホールインワン'
   else
     diff = player_scores[i].to_i - par_scores[i].to_i
-    judge_scores << '3ボギー' if diff == 3
-    judge_scores << '2ボギー' if diff == 2
-    judge_scores << 'ボギー' if diff == 1
-    judge_scores << 'パー' if diff.zero?
-    judge_scores << 'バーディ' if diff == -1
-    judge_scores << 'イーグル' if diff == -2
-    judge_scores << 'アルバトロス' if diff == -3
+    diff >= 2 ? judge_scores << "#{diff}ボギー" : judge_scores << SCORE_MAPPING[diff]
   end
 end
 

--- a/ruby/golf_score.rb
+++ b/ruby/golf_score.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+get_line = []
+par_scores = []
+player_scores = []
+judge_scores = []
+
+ARGF.each do |line|
+  get_line << line
+end
+
+get_line[0].split(',').each do |i|
+  par_scores << i.to_i
+end
+
+get_line[1].split(',').each do |i|
+  player_scores << i.to_i
+end
+
+18.times.each do |i|
+  if player_scores[i] == 1
+    par_scores[i] == 5 ? judge_scores << 'コンドル' : judge_scores << 'ホールインワン'
+  else
+    diff = player_scores[i].to_i - par_scores[i].to_i
+    judge_scores << '3ボギー' if diff == 3
+    judge_scores << '2ボギー' if diff == 2
+    judge_scores << 'ボギー' if diff == 1
+    judge_scores << 'パー' if diff.zero?
+    judge_scores << 'バーディ' if diff == -1
+    judge_scores << 'イーグル' if diff == -2
+    judge_scores << 'アルバトロス' if diff == -3
+  end
+end
+
+puts judge_scores.join(',')


### PR DESCRIPTION
## 課題のリンク
[ゴルフのスコア判定プログラム](https://github.com/happiness-chain/practice/blob/main/08_ruby/002_%E3%82%B4%E3%83%AB%E3%83%95%E3%82%B9%E3%82%B3%E3%82%A2%E5%88%A4%E5%AE%9A.md#%E3%82%B4%E3%83%AB%E3%83%95%E3%81%AE%E3%82%B9%E3%82%B3%E3%82%A2%E5%88%A4%E5%AE%9A%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%A0)

## やったこと
- judge_scoresへの値の代入方法を変更しました
- 2以上のボギーは"#{diff}ボギー"で出力するように変更しました
